### PR TITLE
ci: migrate CI to self-hosted eph-* runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     # is not portable to the NixOS `eph-linux-x64` class. Kept on ubuntu-latest
     # until this job moves to the nix dev env; see the nix-based
     # `wdio-smoke`/`wdio-integration` jobs which already run on eph-linux-x64.
-    runs-on: ubuntu-latest
+    runs-on: eph-linux-x64
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Migrate GitHub-hosted runner to Metacraft Labs self-hosted eph-* class per org policy (GitHub-hosted not permitted).

Substitution (ci.yml line 16): `build` job `runs-on: ubuntu-latest` -> `eph-linux-x64`.

NOTE / concern: The `build` job carried a comment (lines 11-15) deliberately holding it on `ubuntu-latest` ("HOLD (CIP-5 Wave 4): STEP-RISKY. DIY toolchain (actions/setup-node + extractions/setup-just download dynamically-linked prebuilt binaries) is not portable to the NixOS eph-linux-x64 class"). Org policy (all CI on self-hosted eph-*) overrides this hold, so the label was converted; the explanatory comment was left untouched. This job may fail on eph-linux-x64 until its DIY toolchain is moved to the nix dev env -- landing without green CI is authorized. Other jobs were already on eph-* (windows-build: eph-win-x64; nix jobs: eph-linux-x64) and were not modified.