### PR TITLE
ci: trigger CI on `dev`, the actual default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
+# `dev` is the default branch and the base of every recent PR; `main` is
+# retained because it still exists. The previous `[main]`-only filters meant
+# neither pushes to `dev` nor PRs based on it ran any CI.
 on:
   push:
-    branches: [main]
+    branches: [dev, main]
   pull_request:
-    branches: [main]
+    branches: [dev, main]
 
 jobs:
   build:


### PR DESCRIPTION
The `CI` workflow filtered **both** `push` and `pull_request` on `[main]`,
but `dev` is the default branch and the base of every recent PR. Neither
filter matched, so nothing ran.

## Evidence

Run counts from the Actions API, not read off the YAML:

| query | result |
|---|---|
| runs of any workflow on `dev`, ever | **0** |
| last run of `CI` on any branch | 2026-06-29, on `main` |
| PRs merged into `dev` since | #27, #28, #29 — **none with a CI run** |

Both paths were dead, so this was a total blackout: seven weeks of merges
into `dev` landed with no check of any kind.

## Change

`push` and `pull_request` now filter on `[dev, main]`, matching the shape of
the `nim-libvterm` fix. `main` still exists (last pushed 2026-06-29) so it is
kept rather than dropped.

## ⚠️ Expect one red job, and it is pre-existing

The last real run of this workflow (2026-06-29, run `28355114224`) reported:

| job | result |
|---|---|
| `build` | ✅ success |
| `wdio-smoke` | ✅ success |
| `windows-build` | ✅ success |
| `wdio-integration` | ❌ **failure** at `Build codetracer (ct + db-backend binaries)` |

So the likely outcome is three green and `wdio-integration` red. That job
builds four sibling repos from source through Nix, and its failure is a
cross-repo build issue rather than anything in this repository.

Seven weeks of unchecked merges have landed since that snapshot, so treat it
as a lower bound rather than a prediction — the point of merging is to find
out what the real state is.

**Please do not revert this as a breakage.** Reverting restores the blackout.
If `wdio-integration` proves to be a long-standing cross-repo problem, the
right response is a tracked issue against that job, not switching the
reporting back off. I deliberately did not add `continue-on-error`.

## Merge readiness — this one may be capacity-blocked

`wdio-integration` is the heaviest job in the repo and the runner fleet is
capacity-capped. A queued check is not a passing check: if this PR sits with
checks pending, that is scheduling, not success. I did not attempt to verify
the WDIO suite locally — it needs four sibling repos plus `rr`, which is not
reproducible outside the CI workspace layout.

The trigger change itself is verifiable by reading the diff; the YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)