### PR TITLE
ci: repin metacraft-github-actions actions from @main to @dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup dev env
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -110,7 +110,7 @@ jobs:
       # and installs the `dev-exec` wrapper (replacing the open-coded
       # setup-nix step). This job needs no cross-repo siblings.
       - name: Setup dev env
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -180,7 +180,7 @@ jobs:
       # former setup-nix + manifest/resolve/clone steps). codetracer and the
       # lock-managed recorder/backend siblings resolve from the workspace lock.
       - name: Setup dev env
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
After the org-wide `main`->`dev` rename of `metacraft-labs/metacraft-github-actions`, its old `main` branch no longer resolves for GitHub Actions (`git/ref/heads/main` 404s; `@main` fails at action-load). This repins every `uses: metacraft-labs/metacraft-github-actions/<action>@main` here to `@dev` (the new mainline).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>